### PR TITLE
Add script to build mandrelJDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Building mandrelJDK locally
 
 ```shell
-JAVA_HOME=/opt/jvms/openjdk-11.0.8+4/ MX_HOME=~/code/mx MANDREL_REPO=~/code/mandrel  MANDREL_JDK=./mandrelJDK  ./src/buildJDK.sh
+JAVA_HOME=/opt/jvms/openjdk-11.0.8+4/ MX_HOME=~/code/mx MANDREL_REPO=~/code/mandrel  MANDREL_JDK=./mandrelJDK  ./buildJDK.sh
 ```
 
 where:

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Building mandrelJDK locally
 
 ```shell
-JAVA_HOME=/opt/jvms/openjdk-11.0.8+4/ MX_HOME=~/code/mx MANDREL_REPO=~/code/mandrel  MANDREL_JDK=./mandrelJDK  ./buildJDK.sh
+JAVA_HOME=/opt/jvms/openjdk-11.0.8+4/ MX_HOME=~/code/mx MANDREL_REPO=~/code/mandrel MANDREL_HOME=./mandrelJDK  ./buildJDK.sh
 ```
 
 where:
 * `JAVA_HOME` is the path to the OpenJDK you want to use for building mandrel
 * `MX_HOME` is the path where you cloned https://github.com/graalvm/mx
 * `MANDREL_REPO` is the path where you cloned https://github.com/graalvm/mandrel
-* `MANDREL_JDK` is the path where you want mandrel to be installed, after completion you will be
+* `MANDREL_HOME` is the path where you want mandrel to be installed, after completion you will be
  able to use this as `JAVA_HOME` or/and `GRAALVM_HOME` in your projects (e.g. quarkus)
  
 You can also add `VERBOSE=true` to see the commands run by the script

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+# Building mandrelJDK locally
+
+```shell
+JAVA_HOME=/opt/jvms/openjdk-11.0.8+4/ MX_HOME=~/code/mx MANDREL_REPO=~/code/mandrel  MANDREL_JDK=./mandrelJDK  ./src/buildJDK.sh
+```
+
+where:
+* `JAVA_HOME` is the path to the OpenJDK you want to use for building mandrel
+* `MX_HOME` is the path where you cloned https://github.com/graalvm/mx
+* `MANDREL_REPO` is the path where you cloned https://github.com/graalvm/mandrel
+* `MANDREL_JDK` is the path where you want mandrel to be installed, after completion you will be
+ able to use this as `JAVA_HOME` or/and `GRAALVM_HOME` in your projects (e.g. quarkus)
+ 
+You can also add `VERBOSE=true` to see the commands run by the script
+
+# Building maven artifacts using a container
+
 Requirements:
 
 * [`CEKit`](https://github.com/cekit/cekit)

--- a/buildJDK.sh
+++ b/buildJDK.sh
@@ -2,24 +2,27 @@
 
 if [[ "${VERBOSE}" == "true" ]]; then
     set -x
+    VERBOSE_BUILD=--verbose
+    VERBOSE_MX=-v
 fi
 
 MX_HOME=${MX_HOME:-/opt/mx}
 JAVA_HOME=${JAVA_HOME:-/opt/jdk}
 MANDREL_REPO=${MANDREL_REPO:-/tmp/mandrel}
 MANDREL_HOME=${MANDREL_HOME:-/opt/mandrelJDK}
+MAVEN_REPO=${MAVEN_REPO:-/tmp/.m2/repository}
 
 ### Build Mandrel
 ## JVM bits
 basename="$(dirname $0)"
-${JAVA_HOME}/bin/java -ea $basename/src/build.java --version 20.1.0.redhat-00001 --maven-local-repository /tmp/.m2/repository --mx-home ${MX_HOME} --mandrel-home ${MANDREL_REPO}
+${JAVA_HOME}/bin/java -ea $basename/src/build.java ${VERBOSE_BUILD} --version 20.1.0.redhat-00001 --maven-local-repository ${MAVEN_REPO} --mx-home ${MX_HOME} --mandrel-home ${MANDREL_REPO}
 
 ## native bits
 pushd ${MANDREL_REPO}/substratevm
-${MX_HOME}/mx build --projects com.oracle.svm.native.libchelper
-${MX_HOME}/mx build --projects com.oracle.svm.native.jvm.posix
-${MX_HOME}/mx build --projects com.oracle.svm.native.strictmath
-${MX_HOME}/mx build --only native-image.image-bash
+${MX_HOME}/mx ${VERBOSE_MX} build --projects com.oracle.svm.native.libchelper
+${MX_HOME}/mx ${VERBOSE_MX} build --projects com.oracle.svm.native.jvm.posix
+${MX_HOME}/mx ${VERBOSE_MX} build --projects com.oracle.svm.native.strictmath
+${MX_HOME}/mx ${VERBOSE_MX} build --only native-image.image-bash
 popd
 
 ### Copy default JDK

--- a/buildJDK.sh
+++ b/buildJDK.sh
@@ -12,7 +12,7 @@ MANDREL_JDK=${MANDREL_JDK:-/opt/mandrelJDK}
 ### Build Mandrel
 ## JVM bits
 basename="$(dirname $0)"
-${JAVA_HOME}/bin/java -ea $basename/build.java --version 20.1.0.redhat-00001 --maven-local-repository /tmp/.m2/repository --mx-home ${MX_HOME} --mandrel-home ${MANDREL_REPO}
+${JAVA_HOME}/bin/java -ea $basename/src/build.java --version 20.1.0.redhat-00001 --maven-local-repository /tmp/.m2/repository --mx-home ${MX_HOME} --mandrel-home ${MANDREL_REPO}
 
 ## native bits
 pushd ${MANDREL_REPO}/substratevm

--- a/buildJDK.sh
+++ b/buildJDK.sh
@@ -7,7 +7,7 @@ fi
 MX_HOME=${MX_HOME:-/opt/mx}
 JAVA_HOME=${JAVA_HOME:-/opt/jdk}
 MANDREL_REPO=${MANDREL_REPO:-/tmp/mandrel}
-MANDREL_JDK=${MANDREL_JDK:-/opt/mandrelJDK}
+MANDREL_HOME=${MANDREL_HOME:-/opt/mandrelJDK}
 
 ### Build Mandrel
 ## JVM bits
@@ -23,49 +23,49 @@ ${MX_HOME}/mx build --only native-image.image-bash
 popd
 
 ### Copy default JDK
-rm -rf ${MANDREL_JDK}
-cp -r ${JAVA_HOME} ${MANDREL_JDK}
+rm -rf ${MANDREL_HOME}
+cp -r ${JAVA_HOME} ${MANDREL_HOME}
 
 ### Copy needed jars
-mkdir ${MANDREL_JDK}/lib/svm
-cp ${MANDREL_REPO}/substratevm/mxbuild/dists/jdk1.8/library-support.jar ${MANDREL_JDK}/lib/svm
+mkdir ${MANDREL_HOME}/lib/svm
+cp ${MANDREL_REPO}/substratevm/mxbuild/dists/jdk1.8/library-support.jar ${MANDREL_HOME}/lib/svm
 
-mkdir ${MANDREL_JDK}/lib/svm/builder
-cp ${MANDREL_REPO}/substratevm/mxbuild/dists/jdk11/{svm,pointsto}.jar ${MANDREL_JDK}/lib/svm/builder
-cp ${MANDREL_REPO}/substratevm/mxbuild/dists/jdk1.8/objectfile.jar ${MANDREL_JDK}/lib/svm/builder
+mkdir ${MANDREL_HOME}/lib/svm/builder
+cp ${MANDREL_REPO}/substratevm/mxbuild/dists/jdk11/{svm,pointsto}.jar ${MANDREL_HOME}/lib/svm/builder
+cp ${MANDREL_REPO}/substratevm/mxbuild/dists/jdk1.8/objectfile.jar ${MANDREL_HOME}/lib/svm/builder
 
-mkdir ${MANDREL_JDK}/languages
-cp ${MANDREL_REPO}/truffle/mxbuild/dists/jdk11/truffle-nfi.jar ${MANDREL_JDK}/languages
+mkdir ${MANDREL_HOME}/languages
+cp ${MANDREL_REPO}/truffle/mxbuild/dists/jdk11/truffle-nfi.jar ${MANDREL_HOME}/languages
 
-mkdir ${MANDREL_JDK}/lib/graalvm
-cp ${MANDREL_REPO}/substratevm/mxbuild/dists/jdk1.8/svm-driver.jar ${MANDREL_JDK}/lib/graalvm
+mkdir ${MANDREL_HOME}/lib/graalvm
+cp ${MANDREL_REPO}/substratevm/mxbuild/dists/jdk1.8/svm-driver.jar ${MANDREL_HOME}/lib/graalvm
 
 ## The following jars are not included in the GraalJDK created by `mx --components="Native Image" build`
-mkdir ${MANDREL_JDK}/lib/jvmci
-cp ${MANDREL_REPO}/sdk/mxbuild/dists/jdk11/graal-sdk.jar ${MANDREL_JDK}/lib/jvmci
-cp ${MANDREL_REPO}/compiler/mxbuild/dists/jdk11/graal.jar ${MANDREL_JDK}/lib/jvmci
+mkdir ${MANDREL_HOME}/lib/jvmci
+cp ${MANDREL_REPO}/sdk/mxbuild/dists/jdk11/graal-sdk.jar ${MANDREL_HOME}/lib/jvmci
+cp ${MANDREL_REPO}/compiler/mxbuild/dists/jdk11/graal.jar ${MANDREL_HOME}/lib/jvmci
 
-mkdir ${MANDREL_JDK}/lib/truffle
-cp ${MANDREL_REPO}/truffle/mxbuild/dists/jdk11/truffle-api.jar ${MANDREL_JDK}/lib/truffle
+mkdir ${MANDREL_HOME}/lib/truffle
+cp ${MANDREL_REPO}/truffle/mxbuild/dists/jdk11/truffle-api.jar ${MANDREL_HOME}/lib/truffle
 
 
 ### Copy native bits
-mkdir -p ${MANDREL_JDK}/lib/svm/clibraries/linux-amd64/include
-cp ${MANDREL_REPO}/substratevm/src/com.oracle.svm.native.libchelper/include/amd64cpufeatures.h ${MANDREL_JDK}/lib/svm/clibraries/linux-amd64/include
-cp ${MANDREL_REPO}/substratevm/src/com.oracle.svm.native.libchelper/include/aarch64cpufeatures.h ${MANDREL_JDK}/lib/svm/clibraries/linux-amd64/include
-cp ${MANDREL_REPO}/substratevm/src/com.oracle.svm.libffi/include/svm_libffi.h ${MANDREL_JDK}/lib/svm/clibraries/linux-amd64/include
-cp ${MANDREL_REPO}/truffle/src/com.oracle.truffle.nfi.native/include/trufflenfi.h ${MANDREL_JDK}/lib/svm/clibraries/linux-amd64/include
-cp ${MANDREL_REPO}/substratevm/mxbuild/linux-amd64/src/com.oracle.svm.native.libchelper/amd64/liblibchelper.a ${MANDREL_JDK}/lib/svm/clibraries/linux-amd64
-cp ${MANDREL_REPO}/substratevm/mxbuild/linux-amd64/src/com.oracle.svm.native.jvm.posix/amd64/libjvm.a ${MANDREL_JDK}/lib/svm/clibraries/linux-amd64
-cp ${MANDREL_REPO}/substratevm/mxbuild/linux-amd64/src/com.oracle.svm.native.strictmath/amd64/libstrictmath.a ${MANDREL_JDK}/lib/svm/clibraries/linux-amd64
-mkdir ${MANDREL_JDK}/lib/svm/bin
-cp ${MANDREL_REPO}/sdk/mxbuild/linux-amd64/native-image.image-bash/native-image ${MANDREL_JDK}/lib/svm/bin/native-image
+mkdir -p ${MANDREL_HOME}/lib/svm/clibraries/linux-amd64/include
+cp ${MANDREL_REPO}/substratevm/src/com.oracle.svm.native.libchelper/include/amd64cpufeatures.h ${MANDREL_HOME}/lib/svm/clibraries/linux-amd64/include
+cp ${MANDREL_REPO}/substratevm/src/com.oracle.svm.native.libchelper/include/aarch64cpufeatures.h ${MANDREL_HOME}/lib/svm/clibraries/linux-amd64/include
+cp ${MANDREL_REPO}/substratevm/src/com.oracle.svm.libffi/include/svm_libffi.h ${MANDREL_HOME}/lib/svm/clibraries/linux-amd64/include
+cp ${MANDREL_REPO}/truffle/src/com.oracle.truffle.nfi.native/include/trufflenfi.h ${MANDREL_HOME}/lib/svm/clibraries/linux-amd64/include
+cp ${MANDREL_REPO}/substratevm/mxbuild/linux-amd64/src/com.oracle.svm.native.libchelper/amd64/liblibchelper.a ${MANDREL_HOME}/lib/svm/clibraries/linux-amd64
+cp ${MANDREL_REPO}/substratevm/mxbuild/linux-amd64/src/com.oracle.svm.native.jvm.posix/amd64/libjvm.a ${MANDREL_HOME}/lib/svm/clibraries/linux-amd64
+cp ${MANDREL_REPO}/substratevm/mxbuild/linux-amd64/src/com.oracle.svm.native.strictmath/amd64/libstrictmath.a ${MANDREL_HOME}/lib/svm/clibraries/linux-amd64
+mkdir ${MANDREL_HOME}/lib/svm/bin
+cp ${MANDREL_REPO}/sdk/mxbuild/linux-amd64/native-image.image-bash/native-image ${MANDREL_HOME}/lib/svm/bin/native-image
 ## Create symbolic link in bin
-ln -s ../lib/svm/bin/native-image ${MANDREL_JDK}/bin/native-image
+ln -s ../lib/svm/bin/native-image ${MANDREL_HOME}/bin/native-image
 
 ### Fix native-image launcher
 sed -i -e 's!EnableJVMCI!EnableJVMCI --upgrade-module-path ${location}/../../jvmci/graal.jar --add-modules "org.graalvm.truffle,org.graalvm.sdk" --module-path ${location}/../../truffle/truffle-api.jar:${location}/../../jvmci/graal-sdk.jar!' \
-    ${MANDREL_JDK}/lib/svm/bin/native-image
+    ${MANDREL_HOME}/lib/svm/bin/native-image
 
 ### Create tarball
-tar -czf mandrel.tar.gz -C ${MANDREL_JDK}/.. mandrelJDK
+tar -czf mandrel.tar.gz -C ${MANDREL_HOME}/.. mandrelJDK

--- a/src/build.java
+++ b/src/build.java
@@ -92,6 +92,8 @@ class Options
     final String mavenRepoId;
     final String mavenURL;
     final String mavenLocalRepository;
+    final String mandrelHome;
+    final String mxHome;
     final List<Dependency> dependencies;
     final boolean skipClean;
 
@@ -103,6 +105,8 @@ class Options
         , String mavenRepoId
         , String mavenURL
         , String mavenLocalRepository
+        , String mandrelHome
+        , String mxHome
         , List<Dependency> dependencies
         , boolean skipClean
     )
@@ -114,6 +118,8 @@ class Options
         this.mavenRepoId = mavenRepoId;
         this.mavenURL = mavenURL;
         this.mavenLocalRepository = mavenLocalRepository;
+        this.mandrelHome = mandrelHome;
+        this.mxHome = mxHome;
         this.dependencies = dependencies;
         this.skipClean = skipClean;
     }
@@ -133,6 +139,10 @@ class Options
 
         final var mavenLocalRepository =
             optional("maven-local-repository", args);
+        final var mandrelHome =
+            optional("mandrel-home", args);
+        final var mxHome =
+            optional("mx-home", args);
 
         final var dependenciesArg = args.get("dependencies");
         final var dependencies = dependenciesArg == null
@@ -149,6 +159,8 @@ class Options
             , mavenRepoId
             , mavenURL
             , mavenLocalRepository
+            , mandrelHome
+            , mxHome
             , dependencies
             , skipClean
         );
@@ -1085,12 +1097,32 @@ class FileSystem
 
     static FileSystem ofSystem(Options options)
     {
-        final var graalHome = Path.of("/tmp", "mandrel");
-        final var mxHome = Path.of("/opt", "mx");
+        final var mandrelHome = mandrelHome(options);
+        final var mxHome = mxHome(options);
         final var userDir = System.getProperty("user.dir");
         final var workingDir = new File(userDir).toPath();
         final var mavenRepoHome = mavenRepoHome(options);
-        return new FileSystem(graalHome, mxHome, workingDir, mavenRepoHome);
+        return new FileSystem(mandrelHome, mxHome, workingDir, mavenRepoHome);
+    }
+
+    private static Path mandrelHome(Options options)
+    {
+        if (options.mandrelHome == null)
+        {
+            return Path.of("/tmp", "mandrel");
+        }
+
+        return Path.of(options.mandrelHome);
+    }
+
+    private static Path mxHome(Options options)
+    {
+        if (options.mxHome == null)
+        {
+            return Path.of("/opt", "mx");
+        }
+
+        return Path.of(options.mxHome);
     }
 
     private static Path mavenRepoHome(Options options)

--- a/src/buildJDK.sh
+++ b/src/buildJDK.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+if [[ "${VERBOSE}" == "true" ]]; then
+    set -x
+fi
+
+MX_HOME=${MX_HOME:-/opt/mx}
+JAVA_HOME=${JAVA_HOME:-/opt/jdk}
+MANDREL_REPO=${MANDREL_REPO:-/tmp/mandrel}
+MANDREL_JDK=${MANDREL_JDK:-/opt/mandrelJDK}
+
+### Build Mandrel
+## JVM bits
+pushd ${MANDREL_REPO}/substratevm
+${MX_HOME}/mx build --dependencies GRAAL_SDK,GRAAL,POINTSTO,OBJECTFILE,SVM_DRIVER
+${MX_HOME}/mx build --only SVM,"com.oracle.svm.graal","com.oracle.svm.truffle","com.oracle.svm.hosted","com.oracle.svm.truffle.nfi","com.oracle.svm.truffle.nfi.posix","com.oracle.svm.truffle.nfi.windows","com.oracle.svm.core.jdk11","com.oracle.svm.core","com.oracle.svm.core.posix","com.oracle.svm.core.windows","com.oracle.svm.core.genscavenge","com.oracle.svm.jni","com.oracle.svm.reflect","com.oracle.svm.util","TRUFFLE_NFI","com.oracle.truffle.nfi","com.oracle.truffle.nfi.spi"
+
+## native bits
+${MX_HOME}/mx build --projects com.oracle.svm.native.libchelper
+${MX_HOME}/mx build --projects com.oracle.svm.native.jvm.posix
+${MX_HOME}/mx build --projects com.oracle.svm.native.strictmath
+${MX_HOME}/mx build --only native-image.image-bash
+popd
+
+### Copy default JDK
+rm -rf ${MANDREL_JDK}
+cp -r ${JAVA_HOME} ${MANDREL_JDK}
+
+### Copy needed jars
+mkdir ${MANDREL_JDK}/lib/svm
+cp ${MANDREL_REPO}/substratevm/mxbuild/dists/jdk1.8/library-support.jar ${MANDREL_JDK}/lib/svm
+
+mkdir ${MANDREL_JDK}/lib/svm/builder
+cp ${MANDREL_REPO}/substratevm/mxbuild/dists/jdk11/{svm,pointsto}.jar ${MANDREL_JDK}/lib/svm/builder
+cp ${MANDREL_REPO}/substratevm/mxbuild/dists/jdk1.8/objectfile.jar ${MANDREL_JDK}/lib/svm/builder
+
+mkdir ${MANDREL_JDK}/languages
+cp ${MANDREL_REPO}/truffle/mxbuild/dists/jdk11/truffle-nfi.jar ${MANDREL_JDK}/languages
+
+mkdir ${MANDREL_JDK}/lib/graalvm
+cp ${MANDREL_REPO}/substratevm/mxbuild/dists/jdk1.8/svm-driver.jar ${MANDREL_JDK}/lib/graalvm
+
+## The following jars are not included in the GraalJDK created by `mx --components="Native Image" build`
+mkdir ${MANDREL_JDK}/lib/jvmci
+cp ${MANDREL_REPO}/sdk/mxbuild/dists/jdk11/graal-sdk.jar ${MANDREL_JDK}/lib/jvmci
+cp ${MANDREL_REPO}/compiler/mxbuild/dists/jdk11/graal.jar ${MANDREL_JDK}/lib/jvmci
+
+mkdir ${MANDREL_JDK}/lib/truffle
+cp ${MANDREL_REPO}/truffle/mxbuild/dists/jdk11/truffle-api.jar ${MANDREL_JDK}/lib/truffle
+
+
+### Copy native bits
+mkdir -p ${MANDREL_JDK}/lib/svm/clibraries/linux-amd64/include
+cp ${MANDREL_REPO}/substratevm/src/com.oracle.svm.native.libchelper/include/amd64cpufeatures.h ${MANDREL_JDK}/lib/svm/clibraries/linux-amd64/include
+cp ${MANDREL_REPO}/substratevm/src/com.oracle.svm.native.libchelper/include/aarch64cpufeatures.h ${MANDREL_JDK}/lib/svm/clibraries/linux-amd64/include
+cp ${MANDREL_REPO}/substratevm/src/com.oracle.svm.libffi/include/svm_libffi.h ${MANDREL_JDK}/lib/svm/clibraries/linux-amd64/include
+cp ${MANDREL_REPO}/truffle/src/com.oracle.truffle.nfi.native/include/trufflenfi.h ${MANDREL_JDK}/lib/svm/clibraries/linux-amd64/include
+cp ${MANDREL_REPO}/substratevm/mxbuild/linux-amd64/src/com.oracle.svm.native.libchelper/amd64/liblibchelper.a ${MANDREL_JDK}/lib/svm/clibraries/linux-amd64
+cp ${MANDREL_REPO}/substratevm/mxbuild/linux-amd64/src/com.oracle.svm.native.jvm.posix/amd64/libjvm.a ${MANDREL_JDK}/lib/svm/clibraries/linux-amd64
+cp ${MANDREL_REPO}/substratevm/mxbuild/linux-amd64/src/com.oracle.svm.native.strictmath/amd64/libstrictmath.a ${MANDREL_JDK}/lib/svm/clibraries/linux-amd64
+mkdir ${MANDREL_JDK}/lib/svm/bin
+cp ${MANDREL_REPO}/sdk/mxbuild/linux-amd64/native-image.image-bash/native-image ${MANDREL_JDK}/lib/svm/bin/native-image
+## Create symbolic link in bin
+ln -s ../lib/svm/bin/native-image ${MANDREL_JDK}/bin/native-image
+
+### Fix native-image launcher
+sed -i -e 's!EnableJVMCI!EnableJVMCI --upgrade-module-path ${location}/../../jvmci/graal.jar --add-modules "org.graalvm.truffle,org.graalvm.sdk" --module-path ${location}/../../truffle/truffle-api.jar:${location}/../../jvmci/graal-sdk.jar!' \
+    ${MANDREL_JDK}/lib/svm/bin/native-image
+
+### Create tarball
+tar -czf mandrel.tar.gz -C ${MANDREL_JDK}/.. mandrelJDK

--- a/src/buildJDK.sh
+++ b/src/buildJDK.sh
@@ -11,11 +11,11 @@ MANDREL_JDK=${MANDREL_JDK:-/opt/mandrelJDK}
 
 ### Build Mandrel
 ## JVM bits
-pushd ${MANDREL_REPO}/substratevm
-${MX_HOME}/mx build --dependencies GRAAL_SDK,GRAAL,POINTSTO,OBJECTFILE,SVM_DRIVER
-${MX_HOME}/mx build --only SVM,"com.oracle.svm.graal","com.oracle.svm.truffle","com.oracle.svm.hosted","com.oracle.svm.truffle.nfi","com.oracle.svm.truffle.nfi.posix","com.oracle.svm.truffle.nfi.windows","com.oracle.svm.core.jdk11","com.oracle.svm.core","com.oracle.svm.core.posix","com.oracle.svm.core.windows","com.oracle.svm.core.genscavenge","com.oracle.svm.jni","com.oracle.svm.reflect","com.oracle.svm.util","TRUFFLE_NFI","com.oracle.truffle.nfi","com.oracle.truffle.nfi.spi"
+basename="$(dirname $0)"
+${JAVA_HOME}/bin/java -ea $basename/build.java --version 20.1.0.redhat-00001 --maven-local-repository /tmp/.m2/repository --mx-home ${MX_HOME} --mandrel-home ${MANDREL_REPO}
 
 ## native bits
+pushd ${MANDREL_REPO}/substratevm
 ${MX_HOME}/mx build --projects com.oracle.svm.native.libchelper
 ${MX_HOME}/mx build --projects com.oracle.svm.native.jvm.posix
 ${MX_HOME}/mx build --projects com.oracle.svm.native.strictmath


### PR DESCRIPTION
This is more or less a copy of https://github.com/zakkak/kolitiri/blob/master/build.sh which I have been using to build a mandrelJDK.

I have edited it to work with the container images created by this repository as well as locally.

e.g. to build a mandrelJDK locally you can use:
`MANDREL_REPO=~/code/graal JAVA_HOME=/opt/jvms/openjdk-11.0.8+4/ MANDREL_JDK=./mandrelJDK MX_HOME=~/code/mx ./src/buildJDK.sh`

to do the same in the container just run `./src/build.sh`

Closes #16 