### PR TITLE
Fixes this situation: mandrelJDK -> /etc/alternatives/java_sdk

### DIFF
--- a/buildJDK.sh
+++ b/buildJDK.sh
@@ -35,7 +35,7 @@ popd
 
 ### Copy default JDK
 rm -rf ${MANDREL_HOME}
-cp -r ${JAVA_HOME} ${MANDREL_HOME}
+cp -r -L ${JAVA_HOME} ${MANDREL_HOME}
 
 ### Copy needed jars
 mkdir ${MANDREL_HOME}/lib/svm


### PR DESCRIPTION
Hello,

This fixes the issue of JAVA_HOME being a symlink to some /usr/java or whatnot.

I hit it on one of the internal build systems that installs java this way.